### PR TITLE
feat: instant dream warp

### DIFF
--- a/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
+++ b/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
@@ -18,10 +18,34 @@ internal sealed class FastDreamWarp : Module {
 		}
 	}
 
-	private static void ModifyDreamNailFSM(PlayMakerFSM fsm) =>
+	private static void ModifyDreamNailFSM(PlayMakerFSM fsm) {
 		fsm.InsertCustomAction("Warp Charge", (fsm) => {
 			if (BossSceneController.IsBossScene && ModuleManager.TryGetActiveModule<FastDreamWarp>(out _)) {
 				fsm.SendEvent("CHARGED");
 			}
 		}, 0);
+
+		bool? origInvincibility = null;
+		fsm.InsertCustomAction("Start", (fsm) => {
+			if (BossSceneController.IsBossScene && PlayerData.instance != null) {
+				origInvincibility = PlayerData.instance.isInvincible;
+				PlayerData.instance.isInvincible = true;
+			}
+		}, 0);
+		fsm.InsertCustomAction("Warp End", (fsm) => {
+			if (BossSceneController.IsBossScene && PlayerData.instance != null && origInvincibility != null) {
+				PlayerData.instance.isInvincible = origInvincibility.Value;
+			}
+		}, 0);
+		fsm.InsertCustomAction("Warp Cancel", (fsm) => {
+			if (BossSceneController.IsBossScene && PlayerData.instance != null && origInvincibility != null) {
+				PlayerData.instance.isInvincible = origInvincibility.Value;
+			}
+		}, 0);
+		fsm.InsertCustomAction("Inactive", (fsm) => {
+			if (BossSceneController.IsBossScene && PlayerData.instance != null && origInvincibility != null) {
+				PlayerData.instance.isInvincible = origInvincibility.Value;
+			}
+		}, 0);
+	}
 }

--- a/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
+++ b/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
@@ -19,9 +19,8 @@ internal sealed class FastDreamWarp : Module {
 	}
 
 	private static void ModifyDreamNailFSM(PlayMakerFSM fsm) {
-		// Add new state. Send FAST_DREAM_WARP if both "dream nail" and "up" are pressed in a boss fight. Otherwise, send CANCEL.
-		var state = fsm.AddState("Fast Dream Warp");
-		state.AddCustomAction(() => {
+		// In state "Start", send FAST_DREAM_WARP if both "dream nail" and "up" are pressed in a boss fight.
+		fsm.InsertCustomAction("Start", () => {
 			var inputHandler = typeof(HeroController).GetField("inputHandler", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(HeroController.instance) as InputHandler;
 			if (BossSceneController.IsBossScene
 				&& inputHandler != null
@@ -29,14 +28,10 @@ internal sealed class FastDreamWarp : Module {
 				&& inputHandler.inputActions.up.IsPressed
 				&& ModuleManager.TryGetActiveModule<FastDreamWarp>(out _)) {
 				fsm.SendEvent("FAST_DREAM_WARP");
-			} else {
-				fsm.SendEvent("CANCEL");
 			}
-		});
+		}, 0);
 
-		// Connect the new state into the graph.
-		fsm.ChangeTransition("Take Control", "FINISHED", "Fast Dream Warp");
-		fsm.AddTransition("Fast Dream Warp", "FAST_DREAM_WARP", "Can Warp?");
-		fsm.AddTransition("Fast Dream Warp", "CANCEL", "Start");
+		// Route FAST_DREAM_WARP to the start of dream warp.
+		fsm.AddTransition("Start", "FAST_DREAM_WARP", "Can Warp?");
 	}
 }

--- a/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
+++ b/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
@@ -21,10 +21,13 @@ internal sealed class FastDreamWarp : Module {
 	private static void ModifyDreamNailFSM(PlayMakerFSM fsm) {
 		// Add new state. Send FAST_DREAM_WARP if both "dream nail" and "up" are pressed in a boss fight. Otherwise, send CANCEL.
 		var state = fsm.AddState("Fast Dream Warp");
-		state.AddAction(new ListenForDreamNail { isNotPressed = new FsmEvent("CANCEL"), eventTarget = FsmEventTarget.Self });
-		state.AddAction(new ListenForUp { isNotPressed = new FsmEvent("CANCEL"), eventTarget = FsmEventTarget.Self, isPressedBool = new FsmBool() });
 		state.AddCustomAction(() => {
-			if (BossSceneController.IsBossScene && ModuleManager.TryGetActiveModule<FastDreamWarp>(out _)) {
+			var inputHandler = typeof(HeroController).GetField("inputHandler", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(HeroController.instance) as InputHandler;
+			if (BossSceneController.IsBossScene
+				&& inputHandler != null
+				&& inputHandler.inputActions.dreamNail.IsPressed
+				&& inputHandler.inputActions.up.IsPressed
+				&& ModuleManager.TryGetActiveModule<FastDreamWarp>(out _)) {
 				fsm.SendEvent("FAST_DREAM_WARP");
 			} else {
 				fsm.SendEvent("CANCEL");


### PR DESCRIPTION
If both "dream nail" and "up" are pressed in a boss fight, skip the "start" and "charge" animations and instantly start the warp.

The warp checks in the state "Can Warp?" are still executed. Dream warp outside of a boss fight is not affected. Other dream nail operations (dream nail for soul; set dream gate) are not affected.

See video: https://youtu.be/Dm_hNrPTNfI


I'm open to move this to a different setting (so we have both "fast dream warp" and "instant dream warp" next to each other). LMK your thoughts.