### PR TITLE
fix: skip start state for instant dream warp

### DIFF
--- a/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
+++ b/GodSeekerPlus/Modules/QoL/FastDreamWarp.cs
@@ -27,7 +27,7 @@ internal sealed class FastDreamWarp : Module {
 
 	private static void ModifyDreamNailFSM(PlayMakerFSM fsm) {
 		fsm.Intercept(new TransitionInterceptor() {
-			fromState = "Start",
+			fromState = "Take Control",
 			eventName = FsmEvent.Finished.Name,
 			toStateDefault = "Entry Cancel Check",
 			toStateCustom = "Can Warp?",


### PR DESCRIPTION
The first change is because `TransitionInterceptor` hooks `fromState` 's FINISHED event which means the actions in the `fromState` will all be finished (including the "start" animation, which we don't want).

The second change: I tried on my side in main branch and it was ineffective because of that condition. Not sure if you have any change on the dev branch makes module/option work differently than main branch.

BTW, FWIW, I cannot build the dev branch on my PC: `SceneEdit` cannot be found.